### PR TITLE
Proxy lifecycle

### DIFF
--- a/example/default.yml
+++ b/example/default.yml
@@ -14,6 +14,14 @@ listeners:
     ## If we can't connect to the server by this time, drop the connection
     connect-timeout: 5000
 
+    ## TCP keepalive configuration.
+    ## keepidle: the seconds before we need to send a keepalive
+    tcp-keepidle: 60
+    ## keepintvl: the interval between keepalives sent
+    tcp-keepintvl: 10
+    ## keepcnt: the nuber of keepalives that need to be dropped before we close
+    tcp-keepcnt: 3
+
     ## The proxy will accept connections on <listen-ip>:<listen-port>
     ## 0.0.0.0 means listen on every interface
     listen-ip: 0.0.0.0

--- a/inc/config.h
+++ b/inc/config.h
@@ -9,12 +9,23 @@
 //#define TPX_ENUM_MISSING -1
 
 
+/* Default keepalive parameters, now shutdown is bounded to 90 seconds */
+#define TPX_DEFAULT_TCP_KEEPIDLE  60
+#define TPX_DEFAULT_TCP_KEEPINTVL 10
+#define TPX_DEFAULT_TCP_KEEPCNT   3
+
 typedef struct tpx_listen_conf_s {
     const char *name; /**< @brief The name of the listener */
     const char *target_ip; /**< @brief The IP address of the upstream server. */
     unsigned int target_port; /**< @brief The port of the upstream service. */
     unsigned int connect_timeout; /**< @brief The timeout for connecting to
                                    * the backend in milliseconds */
+    unsigned int tcp_keepidle; /**< @brief Seconds a connection may sit idle
+                                * before the first keepalive probe. 0 means
+                                * use TPX_DEFAULT_TCP_KEEPIDLE */
+    unsigned int tcp_keepintvl; /**< @brief Seconds between keepalive probes */
+    unsigned int tcp_keepcnt; /**< @brief Unanswered probes before the peer is
+                               * declared dead */
 
     const char *listen_ip; /**< @brief The local IP address to listen on. */
     unsigned int listen_port; /**< @brief The port to listen on. */
@@ -31,6 +42,7 @@ typedef struct tpx_listen_conf_s {
                           */
     const char *servkeypass; /**< @brief The encryption password for the server
                               * key */
+
 } tpx_listen_conf_t;
 
 /** @brief The configuration of the TLS Proxy */
@@ -60,6 +72,15 @@ static const cyaml_schema_field_t listener_fields_schema[] = {
     CYAML_FIELD_UINT(
         "connect-timeout", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
         tpx_listen_conf_t, connect_timeout),
+    CYAML_FIELD_UINT(
+        "tcp-keepidle", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+        tpx_listen_conf_t, tcp_keepidle),
+    CYAML_FIELD_UINT(
+        "tcp-keepintvl", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+        tpx_listen_conf_t, tcp_keepintvl),
+    CYAML_FIELD_UINT(
+        "tcp-keepcnt", CYAML_FLAG_DEFAULT | CYAML_FLAG_OPTIONAL,
+        tpx_listen_conf_t, tcp_keepcnt),
     
     CYAML_FIELD_STRING_PTR(
         "listen-ip", CYAML_FLAG_POINTER, tpx_listen_conf_t, listen_ip,

--- a/inc/listen.h
+++ b/inc/listen.h
@@ -61,10 +61,15 @@ listen_t *create_listener(const tpx_listen_conf_t *config, SSL_CTX *ctx);
  * @param host The hostname or IP address of the local interface to
  *        bind to. This can be 0.0.0.0 or ::0 to bind to all addresses.
  * @param port The port to bind to.
+ * @param keepidle Seconds a connection may sit idle before the first keepalive
+ *        probe. Set on the listener because accept() inherits it.
+ * @param keepintvl Seconds between keepalive probes once they start.
+ * @param keepcnt Unanswered probes before the peer is declared dead.
  * @return The socket we've bound to. If no socket could be bound, just exit.
  */
 int bind_listen_sock(listen_t *listen, const char *host,
-                     const unsigned short port);
+                     const unsigned short port,
+                     int keepidle, int keepintvl, int keepcnt);
 
 /**
  * @brief Resolves a remote host into a struct sockaddr

--- a/inc/proxy.h
+++ b/inc/proxy.h
@@ -113,7 +113,8 @@ tpx_err_t handle_proxy(proxy_t *proxy, int epollfd, uint32_t events,
  */
 proxy_t *create_proxy(int accepted_fd, SSL *ssl,
                       listen_t *listener,
-                      unsigned int conn_timeout);
+                      unsigned int conn_timeout,
+                      int keepidle, int keepintvl, int keepcnt);
 
 /**
  * @brief Add client and server sockets of proxy to epoll.
@@ -175,7 +176,7 @@ tpx_err_t proxy_process_data(proxy_t *proxy, int is_client);
 tpx_err_t proxy_close(proxy_t *proxy, int epollfd);
 
 /** @brief Create a nonblocking socket to connect to. */
-int create_connect(proxy_t *proxy);
+int create_connect(proxy_t *proxy, int keepidle, int keepintvl, int keepcnt);
 
 /** @brief Do we have any queued data to send? */
 int outbuf_empty(proxy_t *proxy, int is_client);

--- a/src/config.c
+++ b/src/config.c
@@ -30,6 +30,18 @@ int tpx_validate_conf_l(const tpx_listen_conf_t *config) {
         fprintf(stderr, "Config error in listener %s: 'target-port' must be a "
                 "valid port number\n", config->name);
         return TPX_FAILURE;
+    } else if (config->tcp_keepidle > INT_MAX) {
+        fprintf(stderr, "Config error in listener %s: 'tcp-keepidle' must be "
+                "less than %d\n", config->name, INT_MAX);
+        return TPX_FAILURE;
+    } else if (config->tcp_keepintvl > INT_MAX) {
+        fprintf(stderr, "Config error in listener %s: 'tcp-keepintvl' must be "
+                "less than %d\n", config->name, INT_MAX);
+        return TPX_FAILURE;
+    } else if (config->tcp_keepcnt > INT_MAX) {
+        fprintf(stderr, "Config error in listener %s: 'tcp-keepcnt' must be "
+                "less than %d\n", config->name, INT_MAX);
+        return TPX_FAILURE;
     }
     return TPX_SUCCESS;
 }

--- a/src/listen.c
+++ b/src/listen.c
@@ -66,6 +66,9 @@ tpx_err_t handle_accept(listen_t *listen, int epollfd) {
         return TPX_FAILURE;
     }
 
+    memcpy((void *)&proxy->client_addr, (void *)&addr, addrlen);
+    proxy->client_addrlen = addrlen;
+
     tpx_err_t retval = proxy_add_to_epoll(proxy, epollfd);
     if (retval == TPX_FAILURE) {
         // Need to call with epollfd=-1 to show that the sockets aren't in epoll

--- a/src/listen.c
+++ b/src/listen.c
@@ -60,6 +60,7 @@ tpx_err_t handle_accept(listen_t *listen, int epollfd) {
     proxy_t *proxy = create_proxy(conn_sock, ssl,
                                   listen, listen->config->connect_timeout);
     if (!proxy) {
+        close(conn_sock);
         SSL_free(ssl);
         fprintf(stderr, "handle_accept: Couldn't create proxy\n");
         return TPX_FAILURE;

--- a/src/listen.c
+++ b/src/listen.c
@@ -32,10 +32,12 @@ tpx_err_t handle_accept(listen_t *listen, int epollfd) {
     int sock_flags;
     if ((sock_flags = fcntl(conn_sock, F_GETFL)) == -1) {
         perror("handle_accept: fcntl(GETFL)");
+        close(conn_sock);
         return TPX_FAILURE;
     }
     if (fcntl(conn_sock, F_SETFL, sock_flags | O_NONBLOCK) == -1) {
         perror("handle_accept: fcntl(SETFL)");
+        close(conn_sock);
         return TPX_FAILURE;
     }
 
@@ -43,6 +45,7 @@ tpx_err_t handle_accept(listen_t *listen, int epollfd) {
     if (ssl == NULL) {
         ERR_print_errors_fp(stderr);
         fprintf(stderr, "handle_accept: SSL_new: Couldn't create SSL ctx\n");
+        close(conn_sock);
         return TPX_FAILURE;
     }
 
@@ -50,6 +53,7 @@ tpx_err_t handle_accept(listen_t *listen, int epollfd) {
         ERR_print_errors_fp(stderr);
         SSL_free(ssl);
         fprintf(stderr, "handle_accept: SSL_set_fd: Couldn't assign sock\n");
+        close(conn_sock);
         return TPX_FAILURE;
     }
 
@@ -60,9 +64,9 @@ tpx_err_t handle_accept(listen_t *listen, int epollfd) {
     proxy_t *proxy = create_proxy(conn_sock, ssl,
                                   listen, listen->config->connect_timeout);
     if (!proxy) {
-        close(conn_sock);
         SSL_free(ssl);
         fprintf(stderr, "handle_accept: Couldn't create proxy\n");
+        close(conn_sock);
         return TPX_FAILURE;
     }
 

--- a/src/listen.c
+++ b/src/listen.c
@@ -5,6 +5,8 @@
 #include <err.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <unistd.h>
@@ -16,6 +18,17 @@
 #include "event.h"
 #include "proxy.h"
 
+
+// Make sure we fallback to defaults
+static void keepalive_conf(const tpx_listen_conf_t *config,
+                           int *idle, int *intvl, int *cnt) {
+    *idle  = config->tcp_keepidle  ? (int)config->tcp_keepidle
+                                   : TPX_DEFAULT_TCP_KEEPIDLE;
+    *intvl = config->tcp_keepintvl ? (int)config->tcp_keepintvl
+                                   : TPX_DEFAULT_TCP_KEEPINTVL;
+    *cnt   = config->tcp_keepcnt   ? (int)config->tcp_keepcnt
+                                   : TPX_DEFAULT_TCP_KEEPCNT;
+}
 
 tpx_err_t handle_accept(listen_t *listen, int epollfd) {
     assert(listen->event_id == EV_LISTEN);
@@ -61,8 +74,12 @@ tpx_err_t handle_accept(listen_t *listen, int epollfd) {
 
     // Programmer beware: Make 100% sure that addr gets copied into the proxy
     // ctx rather than just its pointer.
+    int keepidle, keepintvl, keepcnt;
+    keepalive_conf(listen->config, &keepidle, &keepintvl, &keepcnt);
+
     proxy_t *proxy = create_proxy(conn_sock, ssl,
-                                  listen, listen->config->connect_timeout);
+                                  listen, listen->config->connect_timeout,
+                                  keepidle, keepintvl, keepcnt);
     if (!proxy) {
         SSL_free(ssl);
         fprintf(stderr, "handle_accept: Couldn't create proxy\n");
@@ -89,7 +106,11 @@ listen_t *create_listener(const tpx_listen_conf_t *config, SSL_CTX *ctx) {
     if (!l)
         err(EXIT_FAILURE, "create_listener: malloc");
     
-    int lsock = bind_listen_sock(l, config->listen_ip, config->listen_port);
+    int keepidle, keepintvl, keepcnt;
+    keepalive_conf(config, &keepidle, &keepintvl, &keepcnt);
+
+    int lsock = bind_listen_sock(l, config->listen_ip, config->listen_port,
+                                 keepidle, keepintvl, keepcnt);
     
     if (listen(lsock, SOMAXCONN) < 0)
         err(EXIT_FAILURE, "create_listener: listen");
@@ -111,7 +132,8 @@ listen_t *create_listener(const tpx_listen_conf_t *config, SSL_CTX *ctx) {
 }
 
 int bind_listen_sock(listen_t *l, const char *host,
-                     const unsigned short port) {
+                     const unsigned short port,
+                     int keepidle, int keepintvl, int keepcnt) {
     struct addrinfo hints;
     memset(&hints, 0, sizeof(struct addrinfo));
     hints.ai_family = AF_UNSPEC;
@@ -137,9 +159,31 @@ int bind_listen_sock(listen_t *l, const char *host,
         }
 
         opt = 1;
-        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT,
-                       &opt, sizeof(opt)))
-            err(EXIT_FAILURE, "bind_listen_sock: setsockopt (reuse)");
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == -1)
+            err(EXIT_FAILURE, "bind_listen_sock: setsockopt (reuseaddr)");
+
+        if (setsockopt(fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)) == -1)
+            err(EXIT_FAILURE, "bind_listen_sock: setsockopt (reuseport)");
+
+        // These options are set here and inherited by accepted sockets
+        if (setsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &opt, sizeof(opt)) == -1)
+            err(EXIT_FAILURE, "bind_listen_sock: setsockopt (keepalive)");
+
+        opt = keepidle;
+        if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE,
+                       &opt, sizeof(opt)) == -1)
+            err(EXIT_FAILURE, "bind_listen_sock: setsockopt (keepidle)");
+
+        opt = keepintvl;
+        if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL,
+                       &opt, sizeof(opt)) == -1)
+            err(EXIT_FAILURE, "bind_listen_sock: setsockopt (keepintvl)");
+
+        opt = keepcnt;
+        if (setsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT,
+                       &opt, sizeof(opt)) == -1)
+            err(EXIT_FAILURE, "bind_listen_sock: setsockopt (keepcnt)");
+
         opt = 0;
         if (lp->ai_family == AF_INET6 && setsockopt(fd, IPPROTO_IPV6,
                                                     IPV6_V6ONLY, &opt,

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -37,6 +37,7 @@ proxy_t *create_proxy(int accepted_fd, SSL *ssl,
                        TPX_ERR_ERRNO);
         return NULL;
     }
+    memset(proxy, '\0', sizeof(proxy_t));
 
     proxy->event_id = EV_PROXY;
     proxy->c2s = queue_new();

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -48,12 +48,22 @@ proxy_t *create_proxy(int accepted_fd, SSL *ssl,
     proxy->timer_set = 0;
     proxy->hand_shaken = 0;
 
-    proxy->serv_fd = create_connect(proxy);
+    log_proxy(LL_DEBUG, proxy, "client_connect", NULL, NULL);
+
+    if ((proxy->serv_fd = create_connect(proxy)) == -1) {
+        queue_free(proxy->c2s);
+        queue_free(proxy->s2c);
+
+        // fd hasn't been added to epoll yet, and SSL will be freed outside
+        free(proxy);
+
+        return NULL;
+    }
+
     tpx_err_t ret = proxy_handle_connect(proxy, conn_timeout);
-    if (ret == TPX_SUCCESS) {
+    if (ret == TPX_SUCCESS)
         proxy->state = PS_READY;
-        log_proxy(LL_DEBUG, proxy, "client_connect", NULL, NULL);
-    } else if (ret == TPX_AGAIN)
+    else if (ret == TPX_AGAIN)
         proxy->state = PS_SERVER_CONNECTING;
     else {
         close(proxy->serv_fd);
@@ -64,8 +74,8 @@ proxy_t *create_proxy(int accepted_fd, SSL *ssl,
 
         // fd hasn't been added to epoll yet, and SSL will be freed outside
         free(proxy);
-        
-        proxy = NULL;
+
+        return NULL;
     }
 
     nproxies++;
@@ -86,11 +96,13 @@ int create_connect(proxy_t *proxy) {
         log_proxy(LL_ERROR, proxy, "ioerror",
                   "Couldn't get socket flags of connect socket",
                   strerror(errno));
+        close(conn_sock);
         return -1;
     }
     if (fcntl(conn_sock, F_SETFL, sock_flags | O_NONBLOCK) == -1) {
         log_proxy(LL_ERROR, proxy, "ioerror", "Couldn't set connect socket to "
                   "non-blocking mode", strerror(errno));
+        close(conn_sock);
         return -1;
     }
     return conn_sock;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -202,7 +202,8 @@ tpx_err_t proxy_close(proxy_t *proxy, int epollfd) {
         proxy->timer_set = 0;
     }
 
-    SSL_shutdown(proxy->ssl);
+    if (proxy->ssl)
+        SSL_shutdown(proxy->ssl);
 
     switch (proxy->state) {
     case PS_CLIENT_CONNECTED:

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -50,9 +50,10 @@ proxy_t *create_proxy(int accepted_fd, SSL *ssl,
 
     proxy->serv_fd = create_connect(proxy);
     tpx_err_t ret = proxy_handle_connect(proxy, conn_timeout);
-    if (ret == TPX_SUCCESS)
+    if (ret == TPX_SUCCESS) {
         proxy->state = PS_READY;
-    else if (ret == TPX_AGAIN)
+        log_proxy(LL_DEBUG, proxy, "client_connect", NULL, NULL);
+    } else if (ret == TPX_AGAIN)
         proxy->state = PS_SERVER_CONNECTING;
     else {
         close(proxy->serv_fd);
@@ -66,8 +67,6 @@ proxy_t *create_proxy(int accepted_fd, SSL *ssl,
         
         proxy = NULL;
     }
-
-    log_proxy(LL_DEBUG, proxy, "client_connect", NULL, NULL);
 
     nproxies++;
     return proxy;

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -6,6 +6,8 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <sys/epoll.h>
@@ -25,12 +27,13 @@ static ngx_rbtree_node_t sentinel;
 uint32_t nproxies = 0;
 
 
-int create_connect(proxy_t *proxy);
+int create_connect(proxy_t *proxy, int keepidle, int keepintvl, int keepcnt);
 
 
 proxy_t *create_proxy(int accepted_fd, SSL *ssl,
                       listen_t *listener,
-                      unsigned int conn_timeout) {
+                      unsigned int conn_timeout,
+                      int keepidle, int keepintvl, int keepcnt) {
     proxy_t *proxy = malloc(sizeof(proxy_t));
     if (!proxy) {
         log_system_err(LL_ERROR, "Couldn't allocate memory for proxy",
@@ -51,7 +54,8 @@ proxy_t *create_proxy(int accepted_fd, SSL *ssl,
 
     log_proxy(LL_DEBUG, proxy, "client_connect", NULL, NULL);
 
-    if ((proxy->serv_fd = create_connect(proxy)) == -1) {
+    if ((proxy->serv_fd = create_connect(proxy,
+                                         keepidle, keepintvl, keepcnt)) == -1) {
         queue_free(proxy->c2s);
         queue_free(proxy->s2c);
 
@@ -83,7 +87,7 @@ proxy_t *create_proxy(int accepted_fd, SSL *ssl,
     return proxy;
 }
 
-int create_connect(proxy_t *proxy) {
+int create_connect(proxy_t *proxy, int keepidle, int keepintvl, int keepcnt) {
     assert(proxy);
     int conn_sock = socket(proxy->listener->peer_addr.ss_family, SOCK_STREAM,0);
     if (conn_sock < 0) {
@@ -106,6 +110,34 @@ int create_connect(proxy_t *proxy) {
         close(conn_sock);
         return -1;
     }
+
+    // It's *fine* if keepalive isn't set, we can still go. It just means that
+    // the default Linux kernel keepalive of 72 hours is used
+    int opt = 1;
+    if (setsockopt(conn_sock, SOL_SOCKET, SO_KEEPALIVE,
+                   &opt, sizeof(opt)) == -1)
+        log_proxy(LL_WARN, proxy, "ioerror",
+                  "Couldn't enable keepalive on connect socket",
+                  strerror(errno));
+
+    opt = keepidle;
+    if (setsockopt(conn_sock, IPPROTO_TCP, TCP_KEEPIDLE,
+                   &opt, sizeof(opt)) == -1)
+        log_proxy(LL_WARN, proxy, "ioerror",
+                  "Couldn't set keepidle on connect socket", strerror(errno));
+
+    opt = keepintvl;
+    if (setsockopt(conn_sock, IPPROTO_TCP, TCP_KEEPINTVL,
+                   &opt, sizeof(opt)) == -1)
+        log_proxy(LL_WARN, proxy, "ioerror",
+                  "Couldn't set keepintvl on connect socket", strerror(errno));
+
+    opt = keepcnt;
+    if (setsockopt(conn_sock, IPPROTO_TCP, TCP_KEEPCNT,
+                   &opt, sizeof(opt)) == -1)
+        log_proxy(LL_WARN, proxy, "ioerror",
+                  "Couldn't set keepcnt on connect socket", strerror(errno));
+
     return conn_sock;
 }
 
@@ -170,8 +202,7 @@ tpx_err_t proxy_close(proxy_t *proxy, int epollfd) {
         proxy->timer_set = 0;
     }
 
-    if (proxy->state == PS_SERVER_DISCONNECTED && SSL_shutdown(proxy->ssl) == 0)
-        return TPX_AGAIN;
+    SSL_shutdown(proxy->ssl);
 
     switch (proxy->state) {
     case PS_CLIENT_CONNECTED:

--- a/src/proxy.c
+++ b/src/proxy.c
@@ -115,11 +115,11 @@ tpx_err_t proxy_handle_connect(proxy_t *proxy, unsigned int conn_timeout) {
     int retcode = connect(proxy->serv_fd,
                           (struct sockaddr *)&proxy->listener->peer_addr,
                           proxy->listener->peer_addrlen);
-    if (retcode == -1 && errno != EINPROGRESS) {
+    if (retcode == -1 && errno != EINPROGRESS && errno != EALREADY) {
         log_proxy(LL_ERROR, proxy, "ioerror", "Couldn't connect socket",
                   strerror(errno));
         return TPX_FAILURE;
-    } else if (retcode == -1 && errno == EINPROGRESS) {
+    } else if (retcode == -1 && (errno == EINPROGRESS || errno == EALREADY)) {
         if (proxy->state == PS_CLIENT_CONNECTED) {
             // This is the first time we've tried this, need to set a timeout
             // Hardcoded to 3 seconds for now

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ list(APPEND TEST_FLAGS   "-Wl,--wrap=handle_accept -Wl,--wrap=handle_proxy -Wl,-
 list(APPEND TEST_COMP    " ")
 
 list(APPEND TEST_TARGETS test_proxy)
-list(APPEND TEST_FLAGS   "-Wl,--wrap=connect -Wl,--wrap=socket -Wl,--wrap=fcntl -Wl,--wrap=close -Wl,--wrap=malloc -Wl,--wrap=epoll_ctl -Wl,--wrap=SSL_free -Wl,--wrap=SSL_shutdown -Wl,--wrap=SSL_is_init_finished -Wl,--wrap=read -Wl,--wrap=SSL_read -Wl,--wrap=send -Wl,--wrap=SSL_write -Wl,--wrap=SSL_get_error -Wl,--wrap=queue_peek -Wl,--wrap=queue_peek_last -Wl,--wrap=ngx_rbtree_delete -Wl,--wrap=ngx_rbtree_insert -Wl,--wrap=log_proxy -Wl,--wrap=__assert_fail")
+list(APPEND TEST_FLAGS   "-Wl,--wrap=connect -Wl,--wrap=socket -Wl,--wrap=fcntl -Wl,--wrap=setsockopt -Wl,--wrap=close -Wl,--wrap=malloc -Wl,--wrap=epoll_ctl -Wl,--wrap=SSL_free -Wl,--wrap=SSL_shutdown -Wl,--wrap=SSL_is_init_finished -Wl,--wrap=read -Wl,--wrap=SSL_read -Wl,--wrap=send -Wl,--wrap=SSL_write -Wl,--wrap=SSL_get_error -Wl,--wrap=queue_peek -Wl,--wrap=queue_peek_last -Wl,--wrap=ngx_rbtree_delete -Wl,--wrap=ngx_rbtree_insert -Wl,--wrap=log_proxy -Wl,--wrap=__assert_fail")
 list(APPEND TEST_COMP    " ")
 
 list(APPEND TEST_TARGETS test_listen)

--- a/test/test_listen.c
+++ b/test/test_listen.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -318,6 +319,14 @@ void __wrap_log_proxy(loglevel_t level, proxy_t *proxy, const char *subevent,
 }
 
 
+/* Storage rather than a sentinel address, unlike FAKE_SSL. handle_accept()
+   copies accept()'s peer address into proxy->client_addr the moment
+   create_proxy() returns, so whatever a stubbed create_proxy() hands back is
+   written through before any test gets to look at it - the ((proxy_t *)0x10)
+   this used to be segfaulted there. Tests still only compare it by identity. */
+static proxy_t proxy_fixture;
+#define FAKE_PROXY (&proxy_fixture)
+
 static int reset_recorders(void **state) {
     (void)state;
     memset(&close_log, 0, sizeof(close_log));
@@ -325,6 +334,7 @@ static int reset_recorders(void **state) {
     memset(&create_proxy_log, 0, sizeof(create_proxy_log));
     memset(&add_to_epoll_log, 0, sizeof(add_to_epoll_log));
     memset(&proxy_close_log, 0, sizeof(proxy_close_log));
+    memset(&proxy_fixture, 0, sizeof(proxy_fixture));
     set_accept_peer("192.0.2.77", 51000);
     malloc_override = NULL;
     getaddrinfo_fails_for = NULL;
@@ -339,8 +349,8 @@ static listen_t listener_fixture;
 
 #define ACCEPTED_FD 40
 #define BACKEND_FD  60
-#define FAKE_PROXY  ((proxy_t *)0x10)
 #define FAKE_SSL    ((SSL *)0x20)
+// FAKE_PROXY is declared above reset_recorders, which has to clear it.
 
 static listen_t *make_listener(void) {
     memset(&conf_fixture, 0, sizeof(conf_fixture));
@@ -584,30 +594,30 @@ static void handle_accept_passes_peer_address_to_the_proxy(void **state) {
 /* bind_listen_sock()                                                  */
 /* ------------------------------------------------------------------ */
 
-/* setsockopt()'s third argument is an option name, not a flag word, and
-   src/listen.c passes SO_REUSEADDR | SO_REUSEPORT. On Linux that is 2 | 15,
-   which is 15, which is SO_REUSEPORT. The call returns 0, sets one option and
-   silently drops the other.
+/* One assertion per option, because these were once a single call passing
+   SO_REUSEADDR | SO_REUSEPORT. setsockopt()'s third argument is an option
+   name, not a flag word: on Linux that OR is 2 | 15, which is 15, which is
+   SO_REUSEPORT. It compiled, it returned 0, it set one option and silently
+   dropped the other, and it read exactly like every correct
+   OR-together-your-flags line in the tree (EPOLLIN | EPOLLOUT | EPOLLET two
+   files over) - setsockopt is the odd one out for not taking a mask. Adding
+   SO_KEEPALIVE to the same OR later changed nothing at all, which is what
+   makes a per-option test worth having rather than one that checks the call
+   happened.
 
-   Nothing catches this. It compiles, it is the same shape as every correct
-   OR-together-your-flags line in the file (EPOLLIN | EPOLLOUT | EPOLLET two
-   files over), and setsockopt is the odd one out for not taking a mask. The
-   header even documents both options as being set.
-
-   Severity, measured rather than assumed: I set up a real TIME_WAIT on a
-   loopback port and retried the bind three ways. With no reuse options the
-   bind fails with EADDRINUSE; with SO_REUSEPORT alone - what this code
-   actually produces - it succeeds. So the restart failure you would expect
-   from a missing SO_REUSEADDR does not currently happen, because SO_REUSEPORT
-   covers for it. This is latent, not live. It becomes live the moment anyone
-   drops SO_REUSEPORT, and at that point the line still reads as though
-   SO_REUSEADDR were set. */
+   Severity of the original, measured rather than assumed: with a real
+   TIME_WAIT set up on a loopback port, a bind with no reuse options fails
+   EADDRINUSE, and one with SO_REUSEPORT alone - what the OR actually produced
+   - succeeds. So the restart failure you would expect from a missing
+   SO_REUSEADDR never showed up, because SO_REUSEPORT covered for it. It was
+   latent, not live, and would have gone live the moment anyone dropped
+   SO_REUSEPORT. */
 static void bind_listen_sock_sets_reuseaddr(void **state) {
     (void)state;
     listen_t l;
     memset(&l, 0, sizeof(l));
 
-    int fd = bind_listen_sock(&l, "127.0.0.1", 0);
+    int fd = bind_listen_sock(&l, "127.0.0.1", 0, 60, 10, 3);
     assert_int_not_equal(fd, -1);
 
     int on = -1;
@@ -626,7 +636,7 @@ static void bind_listen_sock_sets_reuseport(void **state) {
     listen_t l;
     memset(&l, 0, sizeof(l));
 
-    int fd = bind_listen_sock(&l, "127.0.0.1", 0);
+    int fd = bind_listen_sock(&l, "127.0.0.1", 0, 60, 10, 3);
     assert_int_not_equal(fd, -1);
 
     int on = -1;
@@ -637,6 +647,44 @@ static void bind_listen_sock_sets_reuseport(void **state) {
     assert_int_equal(on, 1);
 }
 
+/* The third option that was folded into that OR, and the one with the most
+   riding on it. Linux copies SO_KEEPALIVE and the TCP_KEEP* values from the
+   listening socket onto everything accept() returns, so this call is what
+   decides whether a client that dies without sending FIN is ever noticed -
+   there is no idle timeout anywhere in this program, and an unnoticed dead
+   client holds a proxy_t, two descriptors and its slot in nproxies, which
+   blocks graceful shutdown.
+
+   The values are read back rather than taken from the recorder: passing the
+   arguments in the wrong order still gets all three set, and only the kernel's
+   answer distinguishes that from getting it right. */
+static void bind_listen_sock_sets_keepalive(void **state) {
+    (void)state;
+    listen_t l;
+    memset(&l, 0, sizeof(l));
+
+    int fd = bind_listen_sock(&l, "127.0.0.1", 0, 60, 10, 3);
+    assert_int_not_equal(fd, -1);
+
+    int on = -1, idle = -1, intvl = -1, cnt = -1;
+    socklen_t len = sizeof(on);
+    assert_int_equal(getsockopt(fd, SOL_SOCKET, SO_KEEPALIVE, &on, &len), 0);
+    len = sizeof(idle);
+    assert_int_equal(getsockopt(fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle, &len), 0);
+    len = sizeof(intvl);
+    assert_int_equal(getsockopt(fd, IPPROTO_TCP, TCP_KEEPINTVL, &intvl, &len),
+                     0);
+    len = sizeof(cnt);
+    assert_int_equal(getsockopt(fd, IPPROTO_TCP, TCP_KEEPCNT, &cnt, &len), 0);
+
+    close(fd);
+    assert_true(opt_was_set(SOL_SOCKET, SO_KEEPALIVE));
+    assert_int_equal(on, 1);
+    assert_int_equal(idle, 60);
+    assert_int_equal(intvl, 10);
+    assert_int_equal(cnt, 3);
+}
+
 /* Port 0 rather than a hardcoded port: the old suite bound 47239 and left a
    comment accepting defeat if anything else had it. The kernel will hand out a
    free ephemeral port every time, so there is nothing to lose a race with. */
@@ -645,7 +693,7 @@ static void bind_listen_sock_fills_in_the_listen_address(void **state) {
     listen_t l;
     memset(&l, 0, sizeof(l));
 
-    int fd = bind_listen_sock(&l, "127.0.0.1", 0);
+    int fd = bind_listen_sock(&l, "127.0.0.1", 0, 60, 10, 3);
     assert_int_not_equal(fd, -1);
 
     assert_int_equal(l.listen_addr.ss_family, AF_INET);
@@ -669,7 +717,7 @@ static void bind_listen_sock_is_fatal_when_the_host_wont_resolve(void **state) {
     memset(&l, 0, sizeof(l));
 
     getaddrinfo_fails_for = "no-such-host";
-    expect_assert_failure(bind_listen_sock(&l, "no-such-host", 0));
+    expect_assert_failure(bind_listen_sock(&l, "no-such-host", 0, 60, 10, 3));
 }
 
 
@@ -824,6 +872,8 @@ int main(void) {
         cmocka_unit_test_setup(bind_listen_sock_sets_reuseaddr,
                                reset_recorders),
         cmocka_unit_test_setup(bind_listen_sock_sets_reuseport,
+                               reset_recorders),
+        cmocka_unit_test_setup(bind_listen_sock_sets_keepalive,
                                reset_recorders),
         cmocka_unit_test_setup(bind_listen_sock_fills_in_the_listen_address,
                                reset_recorders),

--- a/test/test_listen.c
+++ b/test/test_listen.c
@@ -443,17 +443,16 @@ static void handle_accept_closes_fd_when_ssl_set_fd_fails(void **state) {
     assert_true(was_closed(ACCEPTED_FD));
 }
 
-/* This is the live one. create_proxy() returns NULL whenever connect() to the
-   backend fails outright - a refused connection, no route, the backend simply
-   being down - and on that path it closes the backend socket it opened but
-   never touches the client fd it was handed. handle_accept() then frees the
-   SSL object and returns, and the client fd is stranded.
+/* create_proxy() returns NULL whenever connect() to the backend fails outright
+   - a refused connection, no route, the backend simply being down - and on
+   that path it closes the backend socket it opened but deliberately leaves the
+   client fd alone (test_proxy.c:create_proxy_failure_closes_only_the_socket_
+   it_opened). Ownership of the accepted fd therefore stays here until a proxy
+   exists to take it, and handle_accept() has to close it before returning.
 
-   So: backend down, clients still arriving, one descriptor burned per attempt
-   until the worker hits EMFILE, at which point accept() starts failing and the
-   worker stops serving the connections it could still have served. No debug
-   build required and no attacker required either - an outage on the far side
-   is enough. */
+   Left undone this is a descriptor burned per attempt with the backend down,
+   until the worker hits EMFILE and accept() starts failing, at which point it
+   stops serving the connections it could still have served. */
 static void handle_accept_closes_fd_when_create_proxy_fails(void **state) {
     (void)state;
     accept_up_to_ssl();
@@ -468,8 +467,8 @@ static void handle_accept_closes_fd_when_create_proxy_fails(void **state) {
     assert_true(was_closed(ACCEPTED_FD));
 }
 
-/* The other half of the same path, pinned separately so that fixing the leak
-   above cannot quietly introduce a double free of the SSL object. */
+/* The other half of the same path, pinned separately so that the close above
+   cannot quietly grow into a double free of the SSL object. */
 static void handle_accept_frees_ssl_when_create_proxy_fails(void **state) {
     (void)state;
     accept_up_to_ssl();

--- a/test/test_proxy.c
+++ b/test/test_proxy.c
@@ -457,12 +457,15 @@ static void create_proxy_failure_does_not_log_null_proxy(void **state) {
         assert_non_null(log_proxy_log.proxies[i]);
 }
 
-/* The failure branch closes serv_fd and forgets client_fd, and handle_accept()
-   does not close it either - it only does SSL_free() and returns TPX_FAILURE
-   (src/listen.c:handle_accept()). So the accepted socket leaks on every failed
-   connection, this time holding a client connection open as well as a
-   descriptor. */
-static void create_proxy_failure_closes_accepted_fd(void **state) {
+/* The accepted fd belongs to handle_accept() until a proxy is successfully
+   built around it: on failure create_proxy() hands back NULL and the caller
+   closes it (src/listen.c:handle_accept(), pinned from the other side by
+   test_listen.c:handle_accept_closes_fd_when_create_proxy_fails). So the
+   failure branch must close the backend socket it opened itself and must leave
+   the client fd strictly alone - closing it here too would make every failed
+   connection a double close, and on a busy worker the second close lands on
+   whatever descriptor the number has since been recycled to. */
+static void create_proxy_failure_closes_only_the_socket_it_opened(void **state) {
     (void)state;
     will_return(__wrap_socket, 43);
     will_return(__wrap_fcntl, 0);
@@ -472,7 +475,7 @@ static void create_proxy_failure_closes_accepted_fd(void **state) {
 
     assert_null(create_proxy(42, NULL, make_listener(), 5));
     assert_true(was_closed(43));
-    assert_true(was_closed(42));
+    assert_false(was_closed(42));
 }
 
 /* create_proxy() allocates with malloc() and assigns nine of the eleven
@@ -1046,8 +1049,9 @@ int main(void) {
                                reset_recorders),
         cmocka_unit_test_setup(create_proxy_failure_does_not_log_null_proxy,
                                reset_recorders),
-        cmocka_unit_test_setup(create_proxy_failure_closes_accepted_fd,
-                               reset_recorders),
+        cmocka_unit_test_setup(
+            create_proxy_failure_closes_only_the_socket_it_opened,
+            reset_recorders),
         cmocka_unit_test_setup(create_proxy_initialises_client_addr,
                                reset_recorders),
 

--- a/test/test_proxy.c
+++ b/test/test_proxy.c
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 #include <limits.h>
 #include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -165,6 +166,51 @@ static int was_closed(int fd) {
 }
 
 
+/* Deliberately NOT forwarded to __real_setsockopt, unlike test_listen.c's
+   otherwise identical recorder. Every fd in this file is a number the mocked
+   socket() invented, so the real call fails EBADF - which is exactly what
+   happened when create_connect() first grew its keepalive block: four
+   unmockable syscalls started failing on fd 43 and took every create_proxy()
+   test down with them.
+
+   The value is recorded alongside the option because "was setsockopt called"
+   is not the contract. What matters is that the configured numbers reached the
+   socket, and a recorder that only counted calls would pass just as happily
+   with keepintvl and keepcnt transposed. */
+static struct {
+    unsigned int calls;
+    int level[MAX_RECORDED];
+    int optname[MAX_RECORDED];
+    int value[MAX_RECORDED];
+} setsockopt_log;
+
+int __wrap_setsockopt(int fd, int level, int optname, const void *val,
+                      socklen_t len);
+int __wrap_setsockopt(int fd, int level, int optname, const void *val,
+                      socklen_t len) {
+    (void)fd;
+    if (setsockopt_log.calls < MAX_RECORDED) {
+        setsockopt_log.level[setsockopt_log.calls] = level;
+        setsockopt_log.optname[setsockopt_log.calls] = optname;
+        setsockopt_log.value[setsockopt_log.calls] =
+            (val && len >= (socklen_t)sizeof(int)) ? *(const int *)val : 0;
+    }
+    setsockopt_log.calls++;
+    if (has_mock())
+        return (int)mock();
+    return 0;
+}
+
+static int opt_set_to(int level, int optname, int value) {
+    for (unsigned int i = 0; i < setsockopt_log.calls && i < MAX_RECORDED; ++i)
+        if (setsockopt_log.level[i] == level &&
+            setsockopt_log.optname[i] == optname &&
+            setsockopt_log.value[i] == value)
+            return 1;
+    return 0;
+}
+
+
 /* epoll_ctl records the whole registration, not just the return code, because
    the tagged pointer this proxy hands epoll is the input test_event.c decodes.
    Testing only the return value would leave the producer side unverified. */
@@ -245,6 +291,7 @@ void __wrap___assert_fail(const char *assertion, const char *file,
 static int reset_recorders(void **state) {
     (void)state;
     memset(&close_log, 0, sizeof(close_log));
+    memset(&setsockopt_log, 0, sizeof(setsockopt_log));
     memset(&epoll_log, 0, sizeof(epoll_log));
     memset(&log_proxy_log, 0, sizeof(log_proxy_log));
     assert_fail_calls = 0;
@@ -319,7 +366,7 @@ static void create_connect_reports_socket_failure(void **state) {
     p.listener = make_listener();
 
     will_return(__wrap_socket, -1);
-    assert_int_equal(create_connect(&p), -1);
+    assert_int_equal(create_connect(&p, 60, 10, 3), -1);
     assert_int_equal(close_log.calls, 0);
 }
 
@@ -336,7 +383,7 @@ static void create_connect_closes_socket_when_getfl_fails(void **state) {
 
     will_return(__wrap_socket, 50);
     will_return(__wrap_fcntl, -1);
-    assert_int_equal(create_connect(&p), -1);
+    assert_int_equal(create_connect(&p, 60, 10, 3), -1);
     assert_true(was_closed(50));
 }
 
@@ -349,8 +396,59 @@ static void create_connect_closes_socket_when_setfl_fails(void **state) {
     will_return(__wrap_socket, 50);
     will_return(__wrap_fcntl, 0);
     will_return(__wrap_fcntl, -1);
-    assert_int_equal(create_connect(&p), -1);
+    assert_int_equal(create_connect(&p, 60, 10, 3), -1);
     assert_true(was_closed(50));
+}
+
+/* The whole point of the keepalive work: nothing else in this program will
+   ever notice a backend that dies without sending FIN, because there is no
+   idle timeout anywhere. The claim is therefore not "setsockopt was called"
+   but "the configured numbers reached the socket" - keepintvl and keepcnt are
+   both small ints on the same level, so transposing them is a live mistake
+   that a call-counting test would wave through. */
+static void create_connect_configures_keepalive_on_the_backend(void **state) {
+    (void)state;
+    proxy_t p;
+    memset(&p, 0, sizeof(p));
+    p.listener = make_listener();
+
+    will_return(__wrap_socket, 50);
+    will_return(__wrap_fcntl, 0);
+    will_return(__wrap_fcntl, 0);
+
+    assert_int_equal(create_connect(&p, 60, 10, 3), 50);
+    assert_true(opt_set_to(SOL_SOCKET, SO_KEEPALIVE, 1));
+    assert_true(opt_set_to(IPPROTO_TCP, TCP_KEEPIDLE, 60));
+    assert_true(opt_set_to(IPPROTO_TCP, TCP_KEEPINTVL, 10));
+    assert_true(opt_set_to(IPPROTO_TCP, TCP_KEEPCNT, 3));
+    assert_false(was_closed(50));
+}
+
+/* Keepalive tuning is a refinement, not a precondition. A kernel that refuses
+   TCP_KEEPIDLE leaves a connection that still works and still has keepalive,
+   just on the tcp_keepalive_* sysctl defaults instead. Failing the connection
+   would convert a rejected tuning knob into a dropped client, so the socket is
+   handed back and only the failure is logged.
+
+   The mock queue is armed for all four options, not just the failing one:
+   arming only the second would make the first call consume it and the test
+   would be measuring a refused SO_KEEPALIVE while claiming otherwise. */
+static void create_connect_survives_a_refused_keepalive_option(void **state) {
+    (void)state;
+    proxy_t p;
+    memset(&p, 0, sizeof(p));
+    p.listener = make_listener();
+
+    will_return(__wrap_socket, 50);
+    will_return(__wrap_fcntl, 0);
+    will_return(__wrap_fcntl, 0);
+    will_return(__wrap_setsockopt, 0);      // SO_KEEPALIVE
+    will_return(__wrap_setsockopt, -1);     // TCP_KEEPIDLE refused
+    will_return(__wrap_setsockopt, 0);      // TCP_KEEPINTVL
+    will_return(__wrap_setsockopt, 0);      // TCP_KEEPCNT
+
+    assert_int_equal(create_connect(&p, 60, 10, 3), 50);
+    assert_false(was_closed(50));
 }
 
 
@@ -365,7 +463,7 @@ static void create_proxy_ready_when_connect_completes(void **state) {
     will_return(__wrap_fcntl, 0);
     will_return(__wrap_connect, 0);
 
-    proxy_t *p = create_proxy(42, NULL, make_listener(), 5);
+    proxy_t *p = create_proxy(42, NULL, make_listener(), 5, 60, 10, 3);
     assert_non_null(p);
     assert_int_equal(p->event_id, EV_PROXY);
     assert_non_null(p->c2s);
@@ -389,7 +487,7 @@ static void create_proxy_pending_when_connect_blocks(void **state) {
     will_return(__wrap_connect, EINPROGRESS);
     will_return(__wrap_ngx_rbtree_insert, NULL);
 
-    proxy_t *p = create_proxy(42, NULL, make_listener(), 5);
+    proxy_t *p = create_proxy(42, NULL, make_listener(), 5, 60, 10, 3);
     assert_non_null(p);
     assert_int_equal(p->state, PS_SERVER_CONNECTING);
     assert_int_equal(p->timer_set, 1);
@@ -406,13 +504,13 @@ static void create_proxy_null_when_connect_fails(void **state) {
     will_return(__wrap_connect, -1);
     will_return(__wrap_connect, ECONNREFUSED);
 
-    assert_null(create_proxy(42, NULL, make_listener(), 5));
+    assert_null(create_proxy(42, NULL, make_listener(), 5, 60, 10, 3));
 }
 
 static void create_proxy_null_when_malloc_fails(void **state) {
     (void)state;
     malloc_fails_next = 1;
-    assert_null(create_proxy(42, NULL, make_listener(), 5));
+    assert_null(create_proxy(42, NULL, make_listener(), 5, 60, 10, 3));
     // Nothing was opened, so nothing may be closed or counted.
     assert_int_equal(close_log.calls, 0);
 }
@@ -433,7 +531,7 @@ static void create_proxy_failure_does_not_leak_nproxies(void **state) {
     will_return(__wrap_connect, -1);
     will_return(__wrap_connect, ECONNREFUSED);
 
-    assert_null(create_proxy(42, NULL, make_listener(), 5));
+    assert_null(create_proxy(42, NULL, make_listener(), 5, 60, 10, 3));
     assert_int_equal(nproxies, before);
 }
 
@@ -452,7 +550,7 @@ static void create_proxy_failure_does_not_log_null_proxy(void **state) {
     will_return(__wrap_connect, -1);
     will_return(__wrap_connect, ECONNREFUSED);
 
-    assert_null(create_proxy(42, NULL, make_listener(), 5));
+    assert_null(create_proxy(42, NULL, make_listener(), 5, 60, 10, 3));
     for (unsigned int i = 0; i < log_proxy_log.calls && i < MAX_RECORDED; ++i)
         assert_non_null(log_proxy_log.proxies[i]);
 }
@@ -465,7 +563,8 @@ static void create_proxy_failure_does_not_log_null_proxy(void **state) {
    the client fd strictly alone - closing it here too would make every failed
    connection a double close, and on a busy worker the second close lands on
    whatever descriptor the number has since been recycled to. */
-static void create_proxy_failure_closes_only_the_socket_it_opened(void **state) {
+static void
+create_proxy_failure_closes_only_the_socket_it_opened(void **state) {
     (void)state;
     will_return(__wrap_socket, 43);
     will_return(__wrap_fcntl, 0);
@@ -473,7 +572,7 @@ static void create_proxy_failure_closes_only_the_socket_it_opened(void **state) 
     will_return(__wrap_connect, -1);
     will_return(__wrap_connect, ECONNREFUSED);
 
-    assert_null(create_proxy(42, NULL, make_listener(), 5));
+    assert_null(create_proxy(42, NULL, make_listener(), 5, 60, 10, 3));
     assert_true(was_closed(43));
     assert_false(was_closed(42));
 }
@@ -498,7 +597,7 @@ static void create_proxy_initialises_client_addr(void **state) {
     will_return(__wrap_fcntl, 0);
     will_return(__wrap_connect, 0);
 
-    proxy_t *p = create_proxy(42, NULL, make_listener(), 5);
+    proxy_t *p = create_proxy(42, NULL, make_listener(), 5, 60, 10, 3);
     assert_non_null(p);
     assert_int_equal(p->client_addr.ss_family, AF_UNSPEC);
     assert_int_equal(p->client_addrlen, 0);
@@ -616,11 +715,16 @@ static void add_to_epoll_fails_on_server_registration(void **state) {
 /* proxy_close()                                                       */
 /* ------------------------------------------------------------------ */
 
+/* SSL_shutdown() is armed even though this is the client-disconnected path:
+   proxy_close() sends close_notify on every state now, not only on
+   PS_SERVER_DISCONNECTED, and __wrap_SSL_shutdown forwards to the real one
+   when no mock is queued - which would hand OpenSSL the 0x7 below. */
 static void close_frees_proxy_with_ssl(void **state) {
     (void)state;
     proxy_t *p = new_proxy(PS_CLIENT_DISCONNECTED);
     p->ssl = (SSL *)0x7;
 
+    will_return(__wrap_SSL_shutdown, 1);
     will_return(__wrap_SSL_free, NULL);
     assert_int_equal(proxy_close(p, -1), TPX_CLOSED);
 }
@@ -641,32 +745,32 @@ static void close_completes_when_shutdown_finishes(void **state) {
     assert_int_equal(proxy_close(p, -1), TPX_CLOSED);
 }
 
-/* SSL_shutdown() returning 0 means the close_notify went out but the peer's
-   has not come back, so the proxy has to stay alive. The early return sits
-   above every teardown step, and a partially torn-down proxy that the caller
-   is told to keep using is a use-after-free waiting for its next event, so
-   pin that nothing was released. */
-static void close_leaves_proxy_intact_while_shutdown_pending(void **state) {
+/* SSL_shutdown() returning 0 means our close_notify went out but the peer's
+   has not come back. proxy_close() deliberately does not wait for it, and this
+   pins that it cannot start: an earlier version returned TPX_AGAIN here and
+   kept the proxy alive, which meant a peer that never replied held the
+   proxy_t, both descriptors and its slot in nproxies indefinitely - and
+   nproxies is what app/main.c:child_loop() waits on to finish a graceful
+   shutdown, so one silent peer was enough to make SIGTERM never complete.
+
+   The wait bought nothing to offset that. RFC 5246 7.2.1 requires only that
+   close_notify be sent: "it is not required for the initiator of the close to
+   wait for the responding close_notify alert before closing the read side",
+   and the peer's reply has nothing to tell a proxy that is about to close both
+   descriptors and discard the session.
+
+   Descriptors are left at the -1 new_proxy() gives them: the claim here is the
+   return value, and close_closes_both_fds() owns the fd claim. */
+static void close_completes_when_the_peer_never_replies(void **state) {
     (void)state;
     proxy_t *p = new_proxy(PS_SERVER_DISCONNECTED);
     p->ssl = (SSL *)0x7;
-    p->serv_fd = 11;
-    p->client_fd = 12;
 
     will_return(__wrap_SSL_shutdown, 0);
-    assert_int_equal(proxy_close(p, -1), TPX_AGAIN);
+    will_return(__wrap_SSL_free, NULL);
 
-    assert_non_null(p->ssl);
-    assert_non_null(p->c2s);
-    assert_non_null(p->s2c);
-    assert_int_equal(p->serv_fd, 11);
-    assert_int_equal(p->client_fd, 12);
-    assert_int_equal(close_log.calls, 0);
-
-    p->ssl = NULL;
-    p->serv_fd = -1;
-    p->client_fd = -1;
     assert_int_equal(proxy_close(p, -1), TPX_CLOSED);
+    assert_int_equal(close_log.calls, 0);
 }
 
 static void close_closes_both_fds(void **state) {
@@ -1036,6 +1140,12 @@ int main(void) {
                                reset_recorders),
         cmocka_unit_test_setup(create_connect_closes_socket_when_setfl_fails,
                                reset_recorders),
+        cmocka_unit_test_setup(
+            create_connect_configures_keepalive_on_the_backend,
+            reset_recorders),
+        cmocka_unit_test_setup(
+            create_connect_survives_a_refused_keepalive_option,
+            reset_recorders),
 
         cmocka_unit_test_setup(create_proxy_ready_when_connect_completes,
                                reset_recorders),
@@ -1069,7 +1179,7 @@ int main(void) {
         cmocka_unit_test_setup(close_frees_proxy_without_ssl, reset_recorders),
         cmocka_unit_test_setup(close_completes_when_shutdown_finishes,
                                reset_recorders),
-        cmocka_unit_test_setup(close_leaves_proxy_intact_while_shutdown_pending,
+        cmocka_unit_test_setup(close_completes_when_the_peer_never_replies,
                                reset_recorders),
         cmocka_unit_test_setup(close_closes_both_fds, reset_recorders),
         cmocka_unit_test_setup(close_skips_epoll_when_never_registered,


### PR DESCRIPTION
Closes #29

This solves all of the issues in 29 other than shutdown handling. That deserves its own issue, and it's been causing problems with benchmarks like apib. In general, we're sending RSTs instead of FINs and not flushing the client before closing it.